### PR TITLE
kill!

### DIFF
--- a/example/off.json
+++ b/example/off.json
@@ -16,7 +16,7 @@
                     {
                         "type": "timer",
                         "interval": 2000,
-                        "nextState": "exit"
+                        "nextState": "kill"
                     }
                 ]
             }
@@ -35,8 +35,8 @@
                 "command": "echo off"
             },
             {
-                "type": "exit",
-                "to": "exit"
+                "type": "kill",
+                "to": "kill"
             }
         ]
     }

--- a/runner/config.go
+++ b/runner/config.go
@@ -56,9 +56,9 @@ type CommandTransitionConfig struct {
 }
 
 /*
-ExitTransitionConfig transitions with a command
+KillTransitionConfig transitions with a command
 */
-type ExitTransitionConfig struct {
+type KillTransitionConfig struct {
 	From string `json:"from"`
 	To   string `json:"to"`
 }
@@ -97,8 +97,8 @@ func (config *transitionConfigJSON) UnmarshalJSON(
 		}
 		config.Payload = payload
 
-	case "exit":
-		var payload ExitTransitionConfig
+	case "kill":
+		var payload KillTransitionConfig
 		err = json.Unmarshal(data, &payload)
 		if err != nil {
 			return

--- a/runner/run.go
+++ b/runner/run.go
@@ -19,9 +19,9 @@ type CommandStateChange struct {
 }
 
 /*
-ExitStateChange should exit the process
+KillStateChange should kill the process
 */
-type ExitStateChange struct {
+type KillStateChange struct {
 	NextState string
 }
 
@@ -157,10 +157,10 @@ func transition(
 				break
 			}
 
-		case ExitTransitionConfig:
+		case KillTransitionConfig:
 			if (transitionConfig.From == prevState || transitionConfig.From == "") &&
 				(transitionConfig.To == nextState || transitionConfig.To == "") {
-				stateChange = ExitStateChange{
+				stateChange = KillStateChange{
 					NextState: nextState,
 				}
 				break

--- a/shell/run.go
+++ b/shell/run.go
@@ -95,8 +95,8 @@ func runCommand(
 			case runner.CommandStateChange:
 				inputLines <- stateChange.Command
 
-			case runner.ExitStateChange:
-				signals <- os.Interrupt
+			case runner.KillStateChange:
+				signals <- os.Kill
 			}
 		}
 	}()
@@ -201,8 +201,8 @@ func runCommandPTY(
 			case runner.CommandStateChange:
 				inputLines <- stateChange.Command
 
-			case runner.ExitStateChange:
-				signals <- os.Interrupt
+			case runner.KillStateChange:
+				signals <- os.Kill
 			}
 		}
 	}()


### PR DESCRIPTION
sends kill signal instead of interrupt. Nota that this is also changed in config, in stead of
```yaml
transitions
- type: exit
  to: some-exit-state
```
do
```yaml
transitions
- type: kill
  to: some-exit-state
```
so exit was renamed to kill!